### PR TITLE
Feat: 프로필 이미지 수정 화면 구현, 기존 프로필 이미지 디폴트 선택 처리

### DIFF
--- a/meaning-out/Components/Cells/ProfileImageCollectionViewCell.swift
+++ b/meaning-out/Components/Cells/ProfileImageCollectionViewCell.swift
@@ -23,10 +23,11 @@ class ProfileImageCollectionViewCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        
         configureCellHierarchy()
         configureCellLayout()
-        configureSelectedCellUI()
-        configureCellUI()
+//        configureSelectedCellUI()
+//        configureCellUI()
     }
     
     required init?(coder: NSCoder) {
@@ -72,16 +73,10 @@ class ProfileImageCollectionViewCell: UICollectionViewCell {
         profileImage.clipsToBounds = true
         profileImage.layer.cornerRadius = 35  // 추후 상수화 하기
         profileImage.contentMode = .scaleAspectFit
-
-//        if isActive {
-//            profileImageView.alpha = 1.0
-//            profileImage.layer.borderColor = Resource.Colors.primary.cgColor
-//            profileImage.layer.borderWidth = CGFloat(Constants.Integer.borderWidth.rawValue)
-//        } else {
-            profileImageView.alpha = 0.5
-            profileImage.layer.borderColor = Resource.Colors.lightGray.cgColor
-            profileImage.layer.borderWidth = CGFloat(Constants.Integer.borderWidthEnabled.rawValue)
-//        }
+        
+        profileImageView.alpha = 0.5
+        profileImage.layer.borderColor = Resource.Colors.lightGray.cgColor
+        profileImage.layer.borderWidth = CGFloat(Constants.Integer.borderWidthEnabled.rawValue)
     }
     
     func configureSelectedCellUI() {

--- a/meaning-out/Controllers/ProfileNicknameImage/ProfileImageViewController.swift
+++ b/meaning-out/Controllers/ProfileNicknameImage/ProfileImageViewController.swift
@@ -16,6 +16,8 @@ class ProfileImageViewController: UIViewController {
     let cameraImageView = UIView()
     let cameraImage = UIImageView()
     
+    private var isDefaultSelected = true
+    
     // 사용자가 선택한 프로필 이미지
     var profileNum: Int = UserDefaultsManager.profile {
         didSet {
@@ -23,6 +25,7 @@ class ProfileImageViewController: UIViewController {
         }
     }
     
+    // 프로필 이미지 컬렉션 뷰
     lazy var profileCollectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionviewLayout())
     
     // 프로필 이미지 컬렉션 뷰 레이아웃 구성
@@ -53,6 +56,12 @@ class ProfileImageViewController: UIViewController {
         configureLayout()
         configureUI()
         configureData()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        profileNum = UserDefaultsManager.profile
     }
     
     private func configureView() {
@@ -148,17 +157,27 @@ extension ProfileImageViewController: UICollectionViewDelegate, UICollectionView
         
         cell.configureCellHierarchy()
         cell.configureCellLayout()
-        profileNum == idx ? cell.configureSelectedCellUI() : cell.configureCellUI()
+        
+        print("여기확인", profileNum, idx)
+        
+        if idx == profileNum && isDefaultSelected {
+            cell.isSelected = true
+            collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .init())
+            cell.configureSelectedCellUI()
+        } else {
+            cell.configureCellUI()
+        }
+        
         cell.configureCellData(data: image)
-        cell.isSelected = true
         
         return cell
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         print("프로필 이미지를 선택했을 때", indexPath.item)
-        profileNum = indexPath.item
         
+        profileNum = indexPath.item
+        isDefaultSelected = false
         UserDefaultsManager.profile = profileNum
         
         print("선택한 값으로 저장한 값 맞는지 확인",  UserDefaultsManager.profile)

--- a/meaning-out/Controllers/Setting/EditNicknameViewController.swift
+++ b/meaning-out/Controllers/Setting/EditNicknameViewController.swift
@@ -27,6 +27,7 @@ class EditNicknameViewController: UIViewController {
     var isValidate = false
     
     let isUser = UserDefaultsManager.isUser
+    
     var nickname = UserDefaultsManager.nickname {
         didSet {
             UserDefaultsManager.nickname = nickname
@@ -47,6 +48,12 @@ class EditNicknameViewController: UIViewController {
         configureUI()
         configureData()
         configureHandler()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        profileNum = UserDefaultsManager.profile
     }
     
     private func configureView() {

--- a/meaning-out/Controllers/Setting/EditProfileImageViewController.swift
+++ b/meaning-out/Controllers/Setting/EditProfileImageViewController.swift
@@ -10,12 +10,53 @@ import UIKit
 import UIKit
 
 class EditProfileImageViewController: UIViewController {
+    
+    let profileImageView = UIView()
+    let profileImage = UIImageView()
+    
+    let cameraImageView = UIView()
+    let cameraImage = UIImageView()
+    
+    private var isDefaultSelected = true
+    
+    // 사용자가 선택한 프로필 이미지
+    var profileNum: Int = UserDefaultsManager.profile {
+        didSet {
+            UserDefaultsManager.profile = profileNum
+        }
+    }
+    
+    // 프로필 이미지 컬렉션 뷰
+    lazy var profileCollectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionviewLayout())
+    
+    // 프로필 이미지 컬렉션 뷰 레이아웃 구성
+    func collectionviewLayout() -> UICollectionViewLayout {
+        let layout = UICollectionViewFlowLayout()
+        
+        let sectionSpaciing: CGFloat = 16
+        let cellSpacing: CGFloat = 16
+        
+        let width = UIScreen.main.bounds.width - (sectionSpaciing) - (cellSpacing)
+        layout.itemSize = CGSize(width: width / 6, height: width / 6)
+        layout.scrollDirection = .vertical
+        
+        layout.minimumInteritemSpacing = cellSpacing
+        layout.minimumLineSpacing = cellSpacing
+        layout.sectionInset = UIEdgeInsets(top: sectionSpaciing, left: sectionSpaciing, bottom: sectionSpaciing, right: sectionSpaciing)  // 셀과 뷰 사이 간격
+        
+        return layout
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         print("프로필 이미지 수정 화면 진입")
+        
         configureView()
+        configureHierarchy()
+        configureLayout()
+        configureUI()
+        configureData()
     }
     
     private func configureView() {
@@ -24,8 +65,113 @@ class EditProfileImageViewController: UIViewController {
         
         addImgBarBtn(image: Resource.SystemImages.left, style: .plain, target: self, action: #selector(backBarButtonClicked), type: .left)
     }
+    
+    private func configureHierarchy() {
+        cameraImageView.addSubview(cameraImage)
+        
+        profileImageView.addSubview(profileImage)
+        profileImageView.addSubview(cameraImageView)
+    
+        view.addSubview(profileImageView)
+        view.addSubview(profileCollectionView)
+        
+        profileCollectionView.delegate = self
+        profileCollectionView.dataSource = self
+        profileCollectionView.register(ProfileImageCollectionViewCell.self, forCellWithReuseIdentifier: ProfileImageCollectionViewCell.id)
+    }
+    
+    private func configureLayout() {
+        profileImageView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+            $0.size.equalTo(100)
+            $0.centerX.equalTo(view.safeAreaLayoutGuide)
+        }
+        
+        profileImage.snp.makeConstraints {
+            $0.top.bottom.equalTo(profileImageView)
+            $0.size.equalTo(profileImageView)
+            $0.centerX.equalTo(profileImageView)
+        }
+        
+        cameraImageView.snp.makeConstraints {
+            $0.trailing.equalTo(profileImage)
+            $0.bottom.equalTo(profileImage).inset(8)
+            $0.size.equalTo(24)
+        }
+        
+        cameraImage.snp.makeConstraints {
+            $0.center.equalTo(cameraImageView)
+            $0.size.equalTo(15)
+        }
+        
+        profileCollectionView.snp.makeConstraints {
+            $0.top.equalTo(profileImageView.snp.bottom).offset(32)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(16)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide)
+        }
+    }
+    
+    private func configureUI() {
+        profileImage.backgroundColor = Resource.Colors.white
+        profileImage.clipsToBounds = true
+        profileImage.layer.cornerRadius = 50  // 추후 상수화 하기
+        profileImage.layer.borderColor = Resource.Colors.primary.cgColor
+        profileImage.layer.borderWidth = CGFloat(Constants.Integer.borderWidth.rawValue)
+        profileImage.contentMode = .scaleAspectFit
+        
+        cameraImageView.backgroundColor = Resource.Colors.primary
+        cameraImageView.layer.cornerRadius = 12  // 추후 상수화 하기
+        
+        cameraImage.image = Resource.SystemImages.camara
+        cameraImage.contentMode = .scaleAspectFit
+        cameraImage.tintColor = Resource.Colors.white
+    }
+    
+    private func configureData() {
+        // 프로필 랜덤 노출 -> 가입 시 고정값으로 수정
+        profileImage.image = Resource.Images.profiles[profileNum]
+    }
 
     @objc func backBarButtonClicked() {
         navigationController?.popViewController(animated: true)
+    }
+}
+
+
+// MARK: EditProfileViewController 익스텐션
+extension EditProfileImageViewController: UICollectionViewDelegate, UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return Resource.Images.profiles.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ProfileImageCollectionViewCell.id, for: indexPath) as! ProfileImageCollectionViewCell
+
+        let idx = indexPath.item
+        let image = Resource.Images.profiles[idx]
+        
+        if idx == profileNum && isDefaultSelected {
+            cell.isSelected = true
+            collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .init())
+            cell.configureSelectedCellUI()
+        } else {
+            cell.configureCellUI()
+        }
+        
+        cell.configureCellData(data: image)
+        
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        print("프로필 이미지를 선택했을 때", indexPath.item)
+        
+        profileNum = indexPath.item
+        UserDefaultsManager.profile = profileNum
+        isDefaultSelected = false
+        
+        print("선택한 값으로 저장한 값 맞는지 확인",  UserDefaultsManager.profile)
+        
+        profileImage.image = Resource.Images.profiles[profileNum]
     }
 }


### PR DESCRIPTION
## ✨ PR 타입
- [x] 기능 작업
- [x] 디자인 작업
- [x] 버그 수정
- [ ] 사소한 수정
- [ ] 리팩토링
- [ ] ETC.

<br />

## 🚀 작업 내용
- [x] 프로필 이미지 수정 화면 구현
- [x] 최초 진입 시 기존 이미지 선택 처리
  - [x] 프로필 이미지 최초 설정 시
  - [x] 기존 프로필 이미지 수정 시
- [x] 이미지 변경 후 되돌아왔을 때 프로필 영역 이미지 수정

<br />

- (왼) 프로필 최초 설정, (오) 기존 프로필 수정

<br />
<img width="350" alt="프로필 이미지 설정-초기 세팅" src="https://github.com/dev-junehee/meaning-out/assets/116873887/a1922ae8-6401-4475-868b-50fd914f5a91">

<img width="350" alt="프로필 이미지 설정-수정" src="https://github.com/dev-junehee/meaning-out/assets/116873887/5c63d598-418b-4390-8e26-478666ea5679">

<br /><br />

## ⛓️ 관련 issue
closed #15

<br />

## 📝 메모
지난 작업 내용 중 #6 에서 사용자가 프로필 이미지를 선택 혹은 수정하러 진입했을 때, 기존의 사용자 프로필(혹은 랜덤으로 지정된) 이미지가 이미 선택되어 있어야 하는 로직을 구현하지 못했는데 위 블로그를 통해서 원인을 파악하고 해결할 수 있었습니다.

- 수정 전

cellForItemAt에서 기존 저장된 프로필 이미지와 indexPath.item이 일치하면 다른 UI 설정 함수 실행하도록 처리

```swift
func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ProfileImageCollectionViewCell.id, for: indexPath) as! ProfileImageCollectionViewCell

    let idx = indexPath.item
    let image = Resource.Images.profiles[idx]
    
    if idx == profileNum {
        cell.isSelected = true
        cell.configureSelectedCellUI()
    } else {
        cell.configureCellUI()
    }
    
    cell.configureCellData(data: image)
    
    return cell
}
```
- 수정 후

디폴트 선택인지 아닌지 Bool 값을 가지는 isDefaultSelected 변수 선언, cellForItemAt에 item과 프로필 이미지가 일치하고 isDefaultSelected가 true이면 해당 셀을 기본 선택 UI 설정 함수 실행, didSelectItemAt에서 다른 셀을 클릭했을 때 Bool 값을 false 처리하는 코드 추가

```swift
private var isDefaultSelected = true
```
```swift
func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ProfileImageCollectionViewCell.id, for: indexPath) as! ProfileImageCollectionViewCell

    let idx = indexPath.item
    let image = Resource.Images.profiles[idx]
    
    if idx == profileNum && isDefaultSelected {
        cell.isSelected = true
        collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .init())
        cell.configureSelectedCellUI()
    } else {
        cell.configureCellUI()
    }
    
    cell.configureCellData(data: image)
    
    return cell
}

func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
    profileNum = indexPath.item
    UserDefaultsManager.profile = profileNum
    isDefaultSelected = false
    profileImage.image = Resource.Images.profiles[profileNum]
}
```
