### PR TITLE
Refactor: showAlert 함수 cancelHandler 삭제, Alert 사용하는 뷰에서 수정 코드 반영

### DIFF
--- a/meaning-out/Controllers/Main/MainViewController.swift
+++ b/meaning-out/Controllers/Main/MainViewController.swift
@@ -114,8 +114,7 @@ extension MainViewController: UISearchBarDelegate {
                 title: Constants.Alert.EmptyString.title.rawValue,
                 message: Constants.Alert.EmptyString.message.rawValue,
                 type: .oneButton,
-                okHandler: nil,
-                cancelHandler: nil
+                okHandler: nil
             )
             searchBar.text = ""
             return

--- a/meaning-out/Controllers/Main/SearchResultViewController.swift
+++ b/meaning-out/Controllers/Main/SearchResultViewController.swift
@@ -176,8 +176,8 @@ class SearchResultViewController: UIViewController {
                 self.showAlert(title: "검색 결과가 없어요.", 
                                message: "다른 검색어를 입력해 주세요!",
                                type: .oneButton,
-                               okHandler: self.alertPopViewController,
-                               cancelHandler: nil)
+                               okHandler: self.alertPopViewController
+                )
                 return
             }
             

--- a/meaning-out/Controllers/ProfileNicknameImage/ProfileNicknameViewController.swift
+++ b/meaning-out/Controllers/ProfileNicknameImage/ProfileNicknameViewController.swift
@@ -207,8 +207,7 @@ class ProfileNicknameViewController: UIViewController {
             showAlert(title: "닉네임 오류",
                       message: "닉네임 입력값에 오류가 발생했어요.\n다시 확인해 주세요.",
                       type: .oneButton,
-                      okHandler: nil,
-                      cancelHandler: nil)
+                      okHandler: nil)
             return
         }
         

--- a/meaning-out/Controllers/Setting/EditNicknameViewController.swift
+++ b/meaning-out/Controllers/Setting/EditNicknameViewController.swift
@@ -61,8 +61,7 @@ class EditNicknameViewController: UIViewController {
             showAlert(title: "유효한 유저가 아니에요!", 
                       message: "온보딩 화면으로 돌아갑니다.",
                       type: .oneButton,
-                      okHandler: backOnboardingController,
-                      cancelHandler: nil
+                      okHandler: backOnboardingController
             )
             return
         }
@@ -209,8 +208,8 @@ class EditNicknameViewController: UIViewController {
             showAlert(title: Constants.Alert.SameNickname.title.rawValue,
                       message: Constants.Alert.SameNickname.message.rawValue,
                       type: .oneButton,
-                      okHandler: alertReturn,
-                      cancelHandler: nil)
+                      okHandler: alertReturn
+            )
             return
         }
         
@@ -219,8 +218,7 @@ class EditNicknameViewController: UIViewController {
             showAlert(title: Constants.Alert.FailValidation.title.rawValue,
                       message: invalidMessage.text,
                       type: .oneButton,
-                      okHandler: alertReturn,
-                      cancelHandler: nil
+                      okHandler: alertReturn
             )
             return
         }
@@ -234,8 +232,7 @@ class EditNicknameViewController: UIViewController {
         showAlert(title: Constants.Alert.EditNickname.title.rawValue,
                   message: Constants.Alert.EditNickname.message.rawValue,
                   type: .oneButton,
-                  okHandler: alertPopViewController,
-                  cancelHandler: nil)
+                  okHandler: alertPopViewController)
     }
 }
 

--- a/meaning-out/Controllers/Setting/SettingViewController.swift
+++ b/meaning-out/Controllers/Setting/SettingViewController.swift
@@ -123,8 +123,7 @@ extension SettingViewController: UITableViewDelegate, UITableViewDataSource {
                 title: Constants.Alert.Cancelation.title.rawValue,
                 message: Constants.Alert.Cancelation.message.rawValue,
                 type: .twoButton,
-                okHandler: alertOkayClicked,
-                cancelHandler: alertCancelClicked
+                okHandler: alertOkayClicked
             )
         }
     }
@@ -147,9 +146,5 @@ extension SettingViewController {
         
         sceneDeleagate?.window?.rootViewController = rootViewController
         sceneDeleagate?.window?.makeKeyAndVisible()
-    }
-    
-    func alertCancelClicked(action: UIAlertAction) {
-        return
     }
 }

--- a/meaning-out/Extension/UIViewController+Extension.swift
+++ b/meaning-out/Extension/UIViewController+Extension.swift
@@ -46,7 +46,7 @@ extension UIViewController {
         }
     }
     
-    func showAlert(title: String?, message: String?, type: AlertType, okHandler: ((UIAlertAction) -> Void)?, cancelHandler: ((UIAlertAction) -> Void)?) {
+    func showAlert(title: String?, message: String?, type: AlertType, okHandler: ((UIAlertAction) -> Void)?) {
         let alert = UIAlertController(
             title: title,
             message: message,
@@ -59,7 +59,7 @@ extension UIViewController {
             break
         case .twoButton:
             let okay = UIAlertAction(title: Constants.Button.okay.rawValue, style: .default, handler: okHandler)
-            let cancel = UIAlertAction(title: Constants.Button.cancel.rawValue, style: .cancel, handler: cancelHandler)
+            let cancel = UIAlertAction(title: Constants.Button.cancel.rawValue, style: .cancel)
             alert.addAction(okay)
             alert.addAction(cancel)
             break


### PR DESCRIPTION
## ✨ PR 타입
- [ ] 기능 작업
- [ ] 디자인 작업
- [ ] 버그 수정
- [ ] 사소한 수정
- [x] 리팩토링
- [ ] ETC.

<br />

## 🚀 작업 내용
- UIViewController에서 전역적으로 사용하는 showAlert 함수 내 cancelHandler 삭제
- Alert 사용하는 뷰에서 수정된 코드 반영

<br />

![스크린샷 2024-06-24 오후 5 36 03](https://github.com/dev-junehee/meaning-out/assets/116873887/50ef80d5-f770-4fc7-aae7-f49b0685641f)

<br /><br />

## ⛓️ 관련 issue
closed #31 

<br />

## 📝 메모
- [UIAlertAction - init](https://developer.apple.com/documentation/uikit/uialertaction/1620097-init)
UIAlertAction에서 handler는 옵셔널이기 단순한 return만 필요한 경우 굳이 핸들러를 할당하지 않아도 되어 해당 부분을 수정하였습니다.