### PR TITLE
Fix: 컬렉션 뷰 스크롤 내렸을 때 정렬 버튼 클릭 시 리로드 안 되는 오류 수정

### DIFF
--- a/meaning-out/Controllers/Search/SearchResultViewController.swift
+++ b/meaning-out/Controllers/Search/SearchResultViewController.swift
@@ -172,6 +172,8 @@ class SearchResultViewController: UIViewController {
     
     func callRequest(sort: String) {
         NetworkManager.shared.getShopping(query: searchText, start: start, sort: sort) { res in
+            print(#function, res)
+            
             if res.total == 0 {
                 self.showAlert(title: "검색 결과가 없어요.", 
                                message: "다른 검색어를 입력해 주세요!",
@@ -193,7 +195,7 @@ class SearchResultViewController: UIViewController {
             self.resultCollectionView.reloadData()
             
             if self.start == 1 {
-                self.resultCollectionView.scrollsToTop = true
+                self.resultCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: true)
             }
         }
     }
@@ -210,6 +212,7 @@ class SearchResultViewController: UIViewController {
         simButton.setClickedButtonUI()
         setUnclickedButtons(buttons: [dateButton, ascButton, dscButton])
         nowSort = Constants.Main.sortSim.rawValue
+        start = 1
         callRequest(sort: Constants.Main.sortSim.rawValue)
         resultCollectionView.reloadData()
     }
@@ -219,6 +222,7 @@ class SearchResultViewController: UIViewController {
         dateButton.setClickedButtonUI()
         setUnclickedButtons(buttons: [simButton, ascButton, dscButton])
         nowSort = Constants.Main.sortDate.rawValue
+        start = 1
         callRequest(sort: Constants.Main.sortDate.rawValue)
         resultCollectionView.reloadData()
     }
@@ -228,6 +232,7 @@ class SearchResultViewController: UIViewController {
         ascButton.setClickedButtonUI()
         setUnclickedButtons(buttons: [simButton, dateButton, dscButton])
         nowSort = Constants.Main.sortDsc.rawValue
+        start = 1
         callRequest(sort: Constants.Main.sortDsc.rawValue)
         resultCollectionView.reloadData()
     }
@@ -237,6 +242,7 @@ class SearchResultViewController: UIViewController {
         dscButton.setClickedButtonUI()
         setUnclickedButtons(buttons: [simButton, dateButton, ascButton])
         nowSort = Constants.Main.sortAsc.rawValue
+        start = 1
         callRequest(sort: Constants.Main.sortAsc.rawValue)
         resultCollectionView.reloadData()
     }


### PR DESCRIPTION
## ✨ PR 타입
- [ ] 기능 작업
- [ ] 디자인 작업
- [x] 버그 수정
- [ ] 사소한 수정
- [ ] 리팩토링
- [ ] ETC.

<br />

## 🚀 작업 내용
- 컬렉션 뷰 스크롤 내렸을 때 정렬 버튼 클릭 시 리로드 안 되는 오류 수정

<br />

![Simulator Screen Recording - iPhone 15 Pro Max - 2024-06-27 at 13 44 14](https://github.com/dev-junehee/meaning-out/assets/116873887/940ba6c5-4765-41a1-8b67-07f882e2845a)

<br /><br />

## ⛓️ 관련 issue
closed #23 

<br />

## 📝 메모
#23 이슈에 트러블 슈팅이 정리되어 있습니다.
