### PR TITLE
Fix(Refactor): 상품 찜 기능 관련 오류 수정 & 리팩토링

### DIFF
--- a/meaning-out/Components/Cells/Search/SearchResultCollectionViewCell.swift
+++ b/meaning-out/Components/Cells/Search/SearchResultCollectionViewCell.swift
@@ -24,7 +24,7 @@ class SearchResultCollectionViewCell: BaseCollectionViewCell {
     
     let likeButton = UIButton()
     
-    var likeList = UserDefaultsManager.like
+    let repository = RealmLikeItemRepository()
     
     override func configureCellHierarchy() {
         let items = [itemImage, itemMallName, itemTitle, itemPrice]
@@ -94,17 +94,14 @@ class SearchResultCollectionViewCell: BaseCollectionViewCell {
         let IMG_URL = URL(string: data.image)
         itemImage.kf.setImage(with: IMG_URL)
         
-        likeButton.backgroundColor = data.isLike || UserDefaultsManager.like.contains(data.title) ? Resource.Colors.white : Resource.Colors.transparentBlack
+        // 찜 상품에 상품 id 포함 여부에 따라 다른 UI 구성
+        let bgColor = repository.findLikeItem(id: data.productId) != nil ? Resource.Colors.white : Resource.Colors.transparentBlack
+        let likeImage = repository.findLikeItem(id: data.productId) != nil ? Resource.SystemImages.likeSelected : Resource.SystemImages.likeUnselected
         
-        let likeImage = data.isLike || UserDefaultsManager.like.contains(data.title) ? Resource.SystemImages.likeSelected : Resource.SystemImages.likeUnselected
+        likeButton.backgroundColor = bgColor
         likeButton.setImage(likeImage, for: .normal)
-        
-        if data.isLike {
-            likeButton.tintColor = Resource.Colors.primary
-        } else {
-            likeButton.tintColor = Resource.Colors.white
-        }
-        
+        likeButton.tintColor = repository.findLikeItem(id: data.productId) != nil ? Resource.Colors.primary : Resource.Colors.white
+     
         itemMallName.text = data.mallName
         itemTitle.text = getItemTitle(data.title)
         itemPrice.text = "\(Int(data.lprice)?.formatted() ?? "-")원"

--- a/meaning-out/Components/Cells/Setting/SettingMenuTableViewCell.swift
+++ b/meaning-out/Components/Cells/Setting/SettingMenuTableViewCell.swift
@@ -22,6 +22,8 @@ final class SettingMenuTableViewCell: BaseTableViewCell {
     let likeCount = UILabel()
     let likeLabel = UILabel()
     
+    private let repository = RealmLikeItemRepository()
+    
     override func configureCellHierarchy() {
         let likeSubViews = [likeImage, likeCount, likeLabel]
         likeSubViews.forEach {
@@ -65,7 +67,7 @@ final class SettingMenuTableViewCell: BaseTableViewCell {
     func configureLikeCellData(data: String) {
         menuTitle.text = data
         likeImage.image = Resource.SystemImages.likeSelected
-        likeCount.text = UserDefaultsManager.getLikeLabel()
+        likeCount.text = repository.getAllLikeItemString()
         likeLabel.text = Constants.SettingOptions.like
     }
     

--- a/meaning-out/Controllers/Like/LikeCategoryViewController.swift
+++ b/meaning-out/Controllers/Like/LikeCategoryViewController.swift
@@ -113,13 +113,18 @@ extension LikeCategoryViewController: UITableViewDelegate, UITableViewDataSource
     
     // 찜 카테고리 밀어서 삭제
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        showAlert(
-            title: Constants.Alert.DeleteLikeCategory.title.rawValue,
-            message: Constants.Alert.DeleteLikeCategory.message.rawValue, type: .twoButton) { _ in
-            guard let categoryList = self.categoryList else { return }
-            let category = categoryList[indexPath.row]
+        guard let categoryList = self.categoryList else { return }
+        let category = categoryList[indexPath.row]
+        
+        if category.detailData.isEmpty {
             self.repository.deleteLikeCategory(category)
-            self.categoryList = self.repository.getAllLikeCategory()
+        } else {
+            showAlert(
+                title: Constants.Alert.DeleteLikeCategory.title.rawValue,
+                message: Constants.Alert.DeleteLikeCategory.message.rawValue, type: .twoButton) { _ in
+                self.repository.deleteLikeCategory(category)
+            }
         }
+        self.categoryList = self.repository.getAllLikeCategory()
     }
 }

--- a/meaning-out/Controllers/Like/LikeCategoryViewController.swift
+++ b/meaning-out/Controllers/Like/LikeCategoryViewController.swift
@@ -51,10 +51,13 @@ final class LikeCategoryViewController: BaseViewController {
         categoryView.emptyView.isHidden = !categoryList.isEmpty
         categoryView.tableView.isHidden = categoryList.isEmpty
         
+        // 찜 카테고리 없을 때 Edit 버튼 숨기고, 편집 모드 해지
         if #available(iOS 16.0, *) {
             navigationItem.leftBarButtonItem?.isHidden = categoryList.isEmpty
+            categoryView.tableView.isEditing = false
         } else {
             navigationItem.leftBarButtonItem?.isEnabled = categoryList.isEmpty
+            categoryView.tableView.isEditing = false
         }
     }
     

--- a/meaning-out/Controllers/Like/LikeDetailViewController.swift
+++ b/meaning-out/Controllers/Like/LikeDetailViewController.swift
@@ -79,6 +79,7 @@ extension LikeDetailViewController: UICollectionViewDelegate, UICollectionViewDa
         // 셀 클릭하면 상품 상세화면으로 이동
         guard let item = category?.detailData[indexPath.item] else { return }
         let searchResultDetailVC = SearchResultDetailViewController()
+        searchResultDetailVC.itemId = item.id
         searchResultDetailVC.itemTitle = item.title
         searchResultDetailVC.itemLink = item.link
         navigationController?.pushViewController(searchResultDetailVC, animated: true)

--- a/meaning-out/Controllers/Like/LikeDetailViewController.swift
+++ b/meaning-out/Controllers/Like/LikeDetailViewController.swift
@@ -18,11 +18,11 @@ final class LikeDetailViewController: BaseViewController {
     override func loadView() {
         self.view = likeView
     }
-    
-//    override func viewDidLoad() {
-//        super.viewDidLoad()
-//        print(category?.detailData)
-//    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        likeView.likeCollectionView.reloadData()
+    }
     
     override func configureViewController() {
         setNavigationItemTitle()
@@ -77,7 +77,11 @@ extension LikeDetailViewController: UICollectionViewDelegate, UICollectionViewDa
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         // 셀 클릭하면 상품 상세화면으로 이동
-        
-        
+        guard let item = category?.detailData[indexPath.item] else { return }
+        let searchResultDetailVC = SearchResultDetailViewController()
+        searchResultDetailVC.itemTitle = item.title
+        searchResultDetailVC.itemLink = item.link
+        navigationController?.pushViewController(searchResultDetailVC, animated: true)
     }
+    
 }

--- a/meaning-out/Controllers/Search/SearchResultDetailViewController.swift
+++ b/meaning-out/Controllers/Search/SearchResultDetailViewController.swift
@@ -16,7 +16,9 @@ import WebKit
 final class SearchResultDetailViewController: BaseViewController {
     
     private let webView = WKWebView()
-    var searchItem: Shopping?
+    
+    var itemTitle: String?
+    var itemLink: String?
     
     var likeList = UserDefaultsManager.like {
         didSet {
@@ -30,7 +32,7 @@ final class SearchResultDetailViewController: BaseViewController {
     }
     
     override func configureViewController() {
-        guard let itemTitle = searchItem?.title else { return }
+        guard let itemTitle = itemTitle else { return }
         navigationItem.title = getItemTitle(itemTitle)
         addImgBarBtn(image: Resource.SystemImages.left, style: .plain, target: self, action: #selector(popViewController), type: .left)
         
@@ -50,7 +52,7 @@ final class SearchResultDetailViewController: BaseViewController {
     }
     
     private func configureData() {
-        guard let itemLink = searchItem?.link else { return }
+        guard let itemLink else { return }
         let URL = URL(string: itemLink)!
         let request = URLRequest(url: URL)
         webView.load(request)
@@ -58,7 +60,7 @@ final class SearchResultDetailViewController: BaseViewController {
     
     @objc private func likeBarButtonClicked() {
         // like -> unLike
-        guard let itemTitle = searchItem?.title else { return }
+        guard let itemTitle = itemTitle else { return }
         if likeList.contains(itemTitle) {
             likeList.append(itemTitle)
             UserDefaultsManager.like = likeList

--- a/meaning-out/Controllers/Search/SearchResultDetailViewController.swift
+++ b/meaning-out/Controllers/Search/SearchResultDetailViewController.swift
@@ -17,14 +17,11 @@ final class SearchResultDetailViewController: BaseViewController {
     
     private let webView = WKWebView()
     
+    var itemId: String?
     var itemTitle: String?
     var itemLink: String?
     
-    var likeList = UserDefaultsManager.like {
-        didSet {
-            configureViewController()
-        }
-    }
+    var repository = RealmLikeItemRepository()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -36,9 +33,13 @@ final class SearchResultDetailViewController: BaseViewController {
         navigationItem.title = getItemTitle(itemTitle)
         addImgBarBtn(image: Resource.SystemImages.left, style: .plain, target: self, action: #selector(popViewController), type: .left)
         
-        // UserDefaults 좋아요 상품 리스트에 해당 상품명이 있으면 like, 없으면 unlike
-        let likeButton = UserDefaultsManager.like.contains(itemTitle) ? Resource.SystemImages.likeSelected : Resource.SystemImages.likeUnselected
+        // 찜한 상품 리스트에 해당 상품이 있으면 like, 없으면 unlike
+        guard let itemId = itemId else { return }
+        let likeButton = repository.isLikeItem(id: itemId) ? Resource.SystemImages.likeSelected : Resource.SystemImages.likeUnselected
         addImgBarBtn(image: likeButton, style: .plain, target: self, action: #selector(likeBarButtonClicked), type: .right)
+        if repository.isLikeItem(id: itemId) {
+            navigationItem.rightBarButtonItem?.tintColor = Resource.Colors.primary
+        }
     }
     
     override func configureHierarchy() {
@@ -59,20 +60,20 @@ final class SearchResultDetailViewController: BaseViewController {
     }
     
     @objc private func likeBarButtonClicked() {
-        // like -> unLike
-        guard let itemTitle = itemTitle else { return }
-        if likeList.contains(itemTitle) {
-            likeList.append(itemTitle)
-            UserDefaultsManager.like = likeList
-        } else {
-            guard let idx = likeList.firstIndex(of: itemTitle) else {
-                print("좋아요 리스트에 해당 상품이 없어요~!")
-                return
-            }
-            likeList.remove(at: idx)
-            UserDefaultsManager.like = likeList
-        }
-        configureViewController()
+//        // like -> unLike
+//        guard let itemTitle = itemTitle else { return }
+//        if likeList.contains(itemTitle) {
+//            likeList.append(itemTitle)
+//            UserDefaultsManager.like = likeList
+//        } else {
+//            guard let idx = likeList.firstIndex(of: itemTitle) else {
+//                print("좋아요 리스트에 해당 상품이 없어요~!")
+//                return
+//            }
+//            likeList.remove(at: idx)
+//            UserDefaultsManager.like = likeList
+//        }
+//        configureViewController()
     }
 
 }

--- a/meaning-out/Controllers/Search/SearchResultViewController.swift
+++ b/meaning-out/Controllers/Search/SearchResultViewController.swift
@@ -228,6 +228,7 @@ extension SearchResultViewController: UICollectionViewDelegate, UICollectionView
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let item = searchResultItem[indexPath.item]
         let searchResultDetailVC = SearchResultDetailViewController()
+        searchResultDetailVC.itemId = item.productId
         searchResultDetailVC.itemTitle = item.title
         searchResultDetailVC.itemLink = item.link
         navigationController?.pushViewController(searchResultDetailVC, animated: true)

--- a/meaning-out/Controllers/Setting/SettingViewController.swift
+++ b/meaning-out/Controllers/Setting/SettingViewController.swift
@@ -127,8 +127,8 @@ extension SettingViewController: UITableViewDelegate, UITableViewDataSource {
 // MARK: Alert Action 알럿 액션 함수
 extension SettingViewController {
     func alertOkayClicked(action: UIAlertAction) {
-        // UserDefaults에 저장된 모든 데이터 삭제
-//        repository.deleteLikeCategory(<#T##category: LikeCategory##LikeCategory#>)
+        // Realm & UserDefaults에 저장된 모든 데이터 삭제
+        repository.deleteAll()
         UserDefaultsManager.deleteAllUserDefaults()
         
         // 온보딩 화면으로 전환

--- a/meaning-out/DataBase/RealmLikeItemRepository.swift
+++ b/meaning-out/DataBase/RealmLikeItemRepository.swift
@@ -79,6 +79,11 @@ final class RealmLikeItemRepository {
         return realm.objects(LikeItem.self)
     }
     
+    // 찜한 상품 개수 (문자열) 불러오기
+    func getAllLikeItemString() -> String {
+        return "\(realm.objects(LikeItem.self).count)개"
+    }
+    
     // 찜한 상품 찾기
     func findLikeItem(id: String) -> LikeItem? {
         return realm.object(ofType: LikeItem.self, forPrimaryKey: id)

--- a/meaning-out/DataBase/RealmLikeItemRepository.swift
+++ b/meaning-out/DataBase/RealmLikeItemRepository.swift
@@ -84,9 +84,19 @@ final class RealmLikeItemRepository {
         return "\(realm.objects(LikeItem.self).count)개"
     }
     
+    
     // 찜한 상품 찾기
     func findLikeItem(id: String) -> LikeItem? {
         return realm.object(ofType: LikeItem.self, forPrimaryKey: id)
+    }
+    
+    // 찜한 상품 여부
+    func isLikeItem(id: String) -> Bool {
+        if findLikeItem(id: id) != nil {
+            return true
+        } else {
+            return false
+        }
     }
     
     // 찜한 상품 삭제하기
@@ -114,4 +124,15 @@ final class RealmLikeItemRepository {
         }
     }
     
+    // 전체 삭제
+    func deleteAll() {
+        do {
+            try realm.write {
+                realm.deleteAll()
+                print("전체 삭제 성공")
+            }
+        } catch {
+            print("전체 삭제 실패", error)
+        }
+    }
 }


### PR DESCRIPTION
## ✨ PR 타입
- [x] 기능 작업
- [ ] 디자인 작업
- [x] 버그 수정
- [x] 사소한 수정
- [x] 리팩토링
- [ ] ETC.

<br />

## 🚀 작업 내용
- 설정 탭
  - 내가 찜한 상품 개수 출력 오류 수정
  - 회원 탈퇴 시 찜 데이터 전체 삭제
- 찜 탭
  - 찜 카테고리에 저장된 상품이 0개일 때 삭제 경고 Alert 미노출 처리
  - 상품 검색 시 이미 찜한 상품에 대한 찜 버튼 UI 수정
  - 상품 클릭 시 상품 상세 화면 연결
  - 찜 카테고리 Edit 모드 고정되는 오류 수정

<br />

| 찜 탭 - 상품 상세 화면 연결 | 회원 탈퇴 시 전체 데이터 삭제 |
|:----------------------:|:---------------------------:|
| ![Simulator Screen Recording - iPhone 15 Pro Max - 2024-07-09 at 19 58 51](https://github.com/dev-junehee/meaning-out/assets/116873887/e12db320-fd93-4e7d-8ad3-8b0d21a409b6) | ![Simulator Screen Recording - iPhone 15 Pro Max - 2024-07-09 at 19 51 48](https://github.com/dev-junehee/meaning-out/assets/116873887/f76d79ea-54fc-45d8-a5ea-0e4df3816c16) |

<br /><br />

## ⛓️ 관련 issue
closed #41 

<br />

## 📝 메모
- #44 지난 작업에서 해결하지 못했던 이슈 모두 해결 완료!
